### PR TITLE
Eager mapping strategy

### DIFF
--- a/include/caterpillar/synthesis/strategies/eager_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/eager_mapping_strategy.hpp
@@ -1,0 +1,128 @@
+/*------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+| Author(s): Mathias Soeken
+*-----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <unordered_set>
+
+#include <mockturtle/traits.hpp>
+#include <mockturtle/utils/node_map.hpp>
+#include <mockturtle/views/topo_view.hpp>
+
+#include "mapping_strategies.hpp"
+
+namespace caterpillar
+{
+
+namespace mt = mockturtle;
+
+/*! \brief Eager mapping strategy.
+ *
+ * This strategy computes each node in topological order.  At each primary
+ * output, all nodes in the transitive fanin are uncomputed that are not
+ * required any longer in successive steps.
+ *
+ * This strategy only finds compute and uncompute steps, but no inplace steps.
+ */
+template<class LogicNetwork>
+class eager_mapping_strategy
+{
+public:
+  /*! \brief Default constructor.
+   *
+   * \param ntk Logic network
+   * \param ps  Mapping strategy parameters
+   */
+  eager_mapping_strategy( LogicNetwork const& ntk, mapping_strategy_params const& ps = {} )
+      : _ntk( ntk ),
+        _ps( ps ),
+        _ref_counts( ntk, 0u )
+  {
+    static_assert( mt::is_network_type_v<LogicNetwork>, "LogicNetwork is not a network type" );
+    static_assert( mt::has_is_constant_v<LogicNetwork>, "LogicNetwork does not implement the is_constant method" );
+    static_assert( mt::has_is_pi_v<LogicNetwork>, "LogicNetwork does not implement the is_pi method" );
+    static_assert( mt::has_fanout_size_v<LogicNetwork>, "LogicNetwork does not implement the fanout_size method" );
+    static_assert( mt::has_foreach_node_v<LogicNetwork>, "LogicNetwork does not implement the foreach_node method" );
+    static_assert( mt::has_foreach_po_v<LogicNetwork>, "LogicNetwork does not implement the foreach_po method" );
+    static_assert( mt::has_foreach_fanin_v<LogicNetwork>, "LogicNetwork does not implement the foreach_fanin method" );
+    static_assert( mt::has_get_node_v<LogicNetwork>, "LogicNetwork does not implement the get_node method" );
+
+    init_refs();
+    run();
+  }
+
+  /*! \brief Iterate over mapping steps. */
+  template<class Fn>
+  inline bool foreach_step( Fn&& fn ) const
+  {
+    for ( auto const& [n, a] : _steps )
+    {
+      fn( n, a );
+    }
+
+    return true;
+  }
+
+private:
+  /* compute reference counters */
+  void init_refs()
+  {
+    _ntk.foreach_node( [&]( auto n ) {
+      _ref_counts[n] = _ntk.fanout_size( n );
+    } );
+    _ntk.foreach_po( [&]( auto f ) {
+      _ref_counts[f]++;
+      _pos.insert( _ntk.get_node( f ) );
+    } );
+  }
+
+  void run()
+  {
+    mt::topo_view<LogicNetwork> topo{_ntk};
+
+    topo.foreach_node( [&]( auto n ) {
+      if ( _ntk.is_constant( n ) || _ntk.is_pi( n ) )
+        return true;
+
+      _steps.emplace_back( n, compute_action{} );
+      if ( _pos.count( n ) )
+      {
+        uncompute_eagerly( n );
+      }
+
+      return true;
+    } );
+  }
+
+  void uncompute_eagerly( mt::node<LogicNetwork> n )
+  {
+    if ( _ntk.is_constant( n ) || _ntk.is_pi( n ) )
+      return;
+
+    _ntk.foreach_fanin( n, [&]( auto const& f ) {
+      const auto child = _ntk.get_node( f );
+      if ( _ntk.is_constant( child ) || _ntk.is_pi( child ) )
+        return;
+
+      if ( --_ref_counts[f] == 0u )
+      {
+        _steps.emplace_back( child, uncompute_action{} );
+        uncompute_eagerly( child );
+      }
+    } );
+  }
+
+private:
+  LogicNetwork const& _ntk;
+  mapping_strategy_params _ps;
+
+  mt::node_map<uint32_t, LogicNetwork> _ref_counts;
+  std::unordered_set<mt::node<LogicNetwork>> _pos;
+
+  std::vector<std::pair<mt::node<LogicNetwork>, mapping_strategy_action>> _steps;
+};
+
+} // namespace caterpillar

--- a/include/caterpillar/synthesis/strategies/eager_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/eager_mapping_strategy.hpp
@@ -74,7 +74,6 @@ private:
       _ref_counts[n] = _ntk.fanout_size( n );
     } );
     _ntk.foreach_po( [&]( auto f ) {
-      _ref_counts[f]++;
       _pos.insert( _ntk.get_node( f ) );
     } );
   }

--- a/test/eager_mapping_strategy.cpp
+++ b/test/eager_mapping_strategy.cpp
@@ -1,0 +1,72 @@
+#include <catch.hpp>
+
+#include <cstdint>
+
+#include <caterpillar/stg_gate.hpp>
+#include <caterpillar/synthesis/lhrs.hpp>
+#include <caterpillar/synthesis/strategies/eager_mapping_strategy.hpp>
+#include <caterpillar/verification/circuit_to_logic_network.hpp>
+#include <kitty/static_truth_table.hpp>
+#include <mockturtle/algorithms/simulation.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <tweedledum/io/write_unicode.hpp>
+#include <tweedledum/networks/netlist.hpp>
+
+TEST_CASE( "Eager mapping strategy for 3-bit sorting network", "[circuit_to_logic_network]" )
+{
+  using namespace caterpillar;
+  using namespace caterpillar::detail;
+  using namespace mockturtle;
+  using namespace tweedledum;
+
+  aig_network sorter;
+  const auto a = sorter.create_pi();
+  const auto b = sorter.create_pi();
+  const auto c = sorter.create_pi();
+
+  const auto w1 = sorter.create_and( a, b );
+  const auto w2 = sorter.create_and( c, w1 );
+  const auto w3 = sorter.create_and( !a, !b );
+  const auto w4 = sorter.create_and( !c, !w1 );
+  const auto w5 = sorter.create_and( !w3, !w4 );
+  const auto w6 = sorter.create_or( c, !w3 );
+
+  sorter.create_po( w2 );
+  sorter.create_po( w5 );
+  sorter.create_po( w6 );
+
+  eager_mapping_strategy strategy( sorter );
+  uint32_t compute{0u}, uncompute{0u};
+
+  strategy.foreach_step( [&]( auto, auto a ) {
+    std::visit(
+        overloaded{
+            []( auto ) {},
+            [&]( compute_action const& ) {
+              ++compute;
+            },
+            [&]( uncompute_action const& ) {
+              ++uncompute;
+            },
+            [&]( compute_inplace_action const& ) {
+              CHECK( false );
+            },
+            [&]( uncompute_inplace_action const& ) {
+              CHECK( false );
+            }},
+        a );
+  } );
+
+  CHECK( compute == 6u );
+  CHECK( uncompute == 3u );
+
+  netlist<stg_gate> circ;
+  logic_network_synthesis_stats st;
+  logic_network_synthesis<netlist<stg_gate>, aig_network, eager_mapping_strategy<aig_network>>(circ, sorter, {}, {}, &st);
+
+  const auto sorter2 = circuit_to_logic_network<aig_network>(circ, st.i_indexes, st.o_indexes);
+  CHECK( sorter2 );
+  CHECK( simulate<kitty::static_truth_table<3>>( sorter ) == simulate<kitty::static_truth_table<3>>( *sorter2 ) );
+
+  //write_unicode(circ, false);
+}

--- a/test/eager_mapping_strategy.cpp
+++ b/test/eager_mapping_strategy.cpp
@@ -12,7 +12,7 @@
 #include <tweedledum/io/write_unicode.hpp>
 #include <tweedledum/networks/netlist.hpp>
 
-TEST_CASE( "Eager mapping strategy for 3-bit sorting network", "[circuit_to_logic_network]" )
+TEST_CASE( "Eager mapping strategy for 3-bit sorting network", "[eager_mapping_strategy]" )
 {
   using namespace caterpillar;
   using namespace caterpillar::detail;


### PR DESCRIPTION
This PR implements an eager mapping strategy. This strategy computes each node in topological order.  At each primary output, all nodes in the transitive fanin are uncomputed that are not required any longer in successive steps.
