### PR TITLE
Refactoring STG gate

### DIFF
--- a/include/caterpillar/synthesis/lhrs.hpp
+++ b/include/caterpillar/synthesis/lhrs.hpp
@@ -177,17 +177,17 @@ private:
   void prepare_outputs()
   {
     std::unordered_map<mt::node<LogicNetwork>, mt::signal<LogicNetwork>> node_to_signals;
-    ntk.foreach_po( [&]( auto s, auto i ) {
+    ntk.foreach_po( [&]( auto s ) {
       auto node = ntk.get_node( s );
 
       if ( const auto it = node_to_signals.find( node ); it != node_to_signals.end() ) //node previously referred
       {
         auto new_i = request_ancilla();
 
-        qnet.add_gate( stg_gate( SetQubits{{node_to_qubit[ntk.node_to_index( node )]}}, new_i ) );
+        qnet.add_gate( tweedledum::gate::cx, node_to_qubit[ntk.node_to_index( node )], new_i );
         if ( ntk.is_complemented( s ) != ntk.is_complemented( node_to_signals[node] ) )
         {
-          qnet.add_gate( stg_gate( SetQubits{{}}, new_i ) );
+          qnet.add_gate( tweedledum::gate::pauli_x, new_i );
         }
         st.o_indexes.push_back( new_i );
       }
@@ -195,7 +195,7 @@ private:
       {
         if ( ntk.is_complemented( s ) )
         {
-          qnet.add_gate( stg_gate( SetQubits{{}}, node_to_qubit[ntk.node_to_index( node )] ) );
+          qnet.add_gate( tweedledum::gate::pauli_x, node_to_qubit[ntk.node_to_index( node )] );
         }
         node_to_signals[node] = s;
         st.o_indexes.push_back( node_to_qubit[ntk.node_to_index( node )] );
@@ -402,56 +402,56 @@ private:
 
   void compute_and( SetQubits controls, uint32_t t )
   {
-    qnet.add_gate( stg_gate( controls, tweedledum::qubit_id( t ) ) );
+    qnet.add_gate( tweedledum::gate::mcx, controls, SetQubits{{t}} );
   }
 
   void compute_or( SetQubits controls, uint32_t t )
   {
-    qnet.add_gate( stg_gate( controls, tweedledum::qubit_id( t ) ) );
-    qnet.add_gate( stg_gate( SetQubits{{}}, tweedledum::qubit_id( t ) ) );
+    qnet.add_gate( tweedledum::gate::mcx, controls, SetQubits{{t}} );
+    qnet.add_gate( tweedledum::gate::pauli_x, tweedledum::qubit_id( t ) );
   }
 
   void compute_xor( uint32_t c1, uint32_t c2, bool inv, uint32_t t )
   {
-    qnet.add_gate( stg_gate( SetQubits{{c1}}, tweedledum::qubit_id( t ) ) );
-    qnet.add_gate( stg_gate( SetQubits{{c2}}, tweedledum::qubit_id( t ) ) );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), tweedledum::qubit_id( t ) );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c2 ), tweedledum::qubit_id( t ) );
     if ( inv )
-      qnet.add_gate( stg_gate( SetQubits{{}}, tweedledum::qubit_id( t ) ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, tweedledum::qubit_id( t ) );
   }
 
   void compute_xor3( uint32_t c1, uint32_t c2, uint32_t c3, bool inv, uint32_t t )
   {
-    qnet.add_gate( stg_gate( SetQubits{{c1}}, t ) );
-    qnet.add_gate( stg_gate( SetQubits{{c2}}, t ) );
-    qnet.add_gate( stg_gate( SetQubits{{c3}}, t ) );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), tweedledum::qubit_id( t ) );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c2 ), tweedledum::qubit_id( t ) );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c3 ), tweedledum::qubit_id( t ) );
     if ( inv )
-      qnet.add_gate( stg_gate( SetQubits{{}}, t ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, tweedledum::qubit_id( t ) );
   }
 
   void compute_maj( uint32_t c1, uint32_t c2, uint32_t c3, bool p1, bool p2, bool p3, uint32_t t )
   {
     if ( p1 )
-      qnet.add_gate( stg_gate( SetQubits{{}}, c1 ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, c1 );
     if ( !p2 ) /* control 2 behaves opposite */
-      qnet.add_gate( stg_gate( SetQubits{{}}, c2 ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, c2 );
     if ( p3 )
-      qnet.add_gate( stg_gate( SetQubits{{}}, c3 ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, c3 );
 
-    qnet.add_gate( stg_gate( SetQubits{{c1}}, c2 ) );
-    qnet.add_gate( stg_gate( SetQubits{{c3}}, c1 ) );
-    qnet.add_gate( stg_gate( SetQubits{{c3}}, t ) );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), c2 );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c3 ), c1 );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c3 ), t );
 
-    qnet.add_gate( stg_gate( SetQubits{{c1, c2}}, t ) );
+    qnet.add_gate( tweedledum::gate::mcx, SetQubits{{c1, c2}}, SetQubits{{t}} );
 
-    qnet.add_gate( stg_gate( SetQubits{{c3}}, c1 ) );
-    qnet.add_gate( stg_gate( SetQubits{{c1}}, c2 ) );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c3 ), c1 );
+    qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), c2 );
 
     if ( p3 )
-      qnet.add_gate( stg_gate( SetQubits{{}}, c3 ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, c3 );
     if ( !p2 )
-      qnet.add_gate( stg_gate( SetQubits{{}}, c2 ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, c2 );
     if ( p1 )
-      qnet.add_gate( stg_gate( SetQubits{{}}, c1 ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, c1 );
   }
 
   void compute_xor_block( SetQubits const& controls, Qubit t )
@@ -459,7 +459,7 @@ private:
     for ( auto c : controls )
     {
       if ( c != t )
-        qnet.add_gate( stg_gate( SetQubits{{c}}, t ) );
+        qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c ), t );
     }
   }
 
@@ -475,46 +475,46 @@ private:
   {
     if ( c1 == t )
     {
-      qnet.add_gate( stg_gate( SetQubits{{c2}}, c1 ) );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c2 ), c1 );
     }
     else if ( c2 == t )
     {
-      qnet.add_gate( stg_gate( SetQubits{{c1}}, c2 ) );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), c2 );
     }
     else
     {
       //std::cerr << "[e] target does not match any control in in-place\n";
-      qnet.add_gate( stg_gate( SetQubits{{c1}}, t ) );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), t );
     }
     if ( inv )
-      qnet.add_gate( stg_gate( SetQubits{{}}, t ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, t );
   }
 
   void compute_xor3_inplace( uint32_t c1, uint32_t c2, uint32_t c3, bool inv, uint32_t t )
   {
     if ( c1 == t )
     {
-      qnet.add_gate( stg_gate( SetQubits{{c2}}, c1 ) );
-      qnet.add_gate( stg_gate( SetQubits{{c3}}, c1 ) );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c2 ), tweedledum::qubit_id( c1 ) );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c3 ), tweedledum::qubit_id( c1 ) );
     }
     else if ( c2 == t )
     {
-      qnet.add_gate( stg_gate( SetQubits{{c1}}, c2 ) );
-      qnet.add_gate( stg_gate( SetQubits{{c3}}, c2 ) );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), c2 );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c3 ), c2 );
     }
     else if ( c3 == t )
     {
-      qnet.add_gate( stg_gate( SetQubits{{c1}}, c3 ) );
-      qnet.add_gate( stg_gate( SetQubits{{c2}}, c3 ) );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), c3 );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c2 ), c3 );
     }
     else
     {
       //std::cerr << "[e] target does not match any control in in-place\n";
-      qnet.add_gate( stg_gate( SetQubits{{c1}}, t ) );
-      qnet.add_gate( stg_gate( SetQubits{{c2}}, t ) );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c1 ), t );
+      qnet.add_gate( tweedledum::gate::cx, tweedledum::qubit_id( c2 ), t );
     }
     if ( inv )
-      qnet.add_gate( stg_gate( SetQubits{{}}, t ) );
+      qnet.add_gate( tweedledum::gate::pauli_x, t );
   }
 
 private:

--- a/include/caterpillar/synthesis/strategies/xag_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/xag_mapping_strategy.hpp
@@ -45,7 +45,7 @@ class xag_mapping_strategy
   {
     std::vector<SignalCone> cones;
         
-    xag.foreach_fanin( node, [&]( auto s, auto i ) {
+    xag.foreach_fanin( node, [&]( auto s ) {
       SignalCone cone;
       cone.node = node;
 

--- a/lib/tweedledum/tweedledum/algorithms/synthesis/stg.hpp
+++ b/lib/tweedledum/tweedledum/algorithms/synthesis/stg.hpp
@@ -28,7 +28,7 @@ struct stg_from_esop_params {};
 
 /*! \brief Synthesize a quantum network from a function by computing exact ESOP representation
  */
-/*struct stg_from_exact_esop {
+//struct stg_from_exact_esop {
 	/*! \brief Synthesize into a _existing_ quantum network
 	 *
 	 * \param network  A quantum network

--- a/test/circuit_to_logic_network.cpp
+++ b/test/circuit_to_logic_network.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <caterpillar/verification/circuit_to_logic_network.hpp>
+#include <caterpillar/stg_gate.hpp>
 #include <kitty/dynamic_truth_table.hpp>
 #include <kitty/constructors.hpp>
 #include <kitty/static_truth_table.hpp>
@@ -18,7 +19,7 @@ TEST_CASE("Convert simple reversible circuit to XAG", "[circuit_to_logic_network
   using namespace mockturtle;
   using namespace tweedledum;
 
-  netlist<mcmt_gate> circ;
+  netlist<stg_gate> circ;
   const auto a = circ.add_qubit();
   const auto b = circ.add_qubit();
   const auto c = circ.add_qubit();
@@ -53,7 +54,7 @@ TEST_CASE("Convert simple reversible circuit with negated controls to XAG", "[ci
   using namespace mockturtle;
   using namespace tweedledum;
 
-  netlist<mcmt_gate> circ;
+  netlist<stg_gate> circ;
   const auto a = circ.add_qubit();
   const auto b = circ.add_qubit();
   const auto c = circ.add_qubit();
@@ -88,7 +89,7 @@ TEST_CASE("Convert incrementer XAG", "[circuit_to_logic_network]")
   using namespace mockturtle;
   using namespace tweedledum;
 
-  netlist<mcmt_gate> circ;
+  netlist<stg_gate> circ;
   const auto a = circ.add_qubit();
   const auto b = circ.add_qubit();
   const auto c = circ.add_qubit();

--- a/test/lhrs.cpp
+++ b/test/lhrs.cpp
@@ -122,7 +122,7 @@ TEST_CASE( "synthesize multioutput maj3", "[multiout MAJ]" )
 
   const auto ntk = circuit_to_logic_network<xag_network>( t_net, st.i_indexes, st.o_indexes );
 
-  kitty::static_truth_table<3> maj, not_maj;
+  kitty::static_truth_table<3> maj;
   kitty::create_from_binary_string( maj, "11101000" );
 
   CHECK( simulate<kitty::static_truth_table<3>>( *ntk )[0] == maj );


### PR DESCRIPTION
This PR makes `stg_gate` more generic such that it can be used also in other synthesis algorithms.

Contrary, it makes `logic_network_synthesis` more generic such that other gates can also be used with it.
