### PR TITLE
Reorganizing mapping strategies

### DIFF
--- a/include/caterpillar/synthesis/lhrs.hpp
+++ b/include/caterpillar/synthesis/lhrs.hpp
@@ -6,7 +6,7 @@
 *-----------------------------------------------------------------------------*/
 #pragma once
 #include "../stg_gate.hpp"
-#include "./strategies/mapping_strategies.hpp"
+#include "strategies/mapping_strategy.hpp"
 
 #include <array>
 #include <cstdint>
@@ -16,9 +16,8 @@
 #include <mockturtle/utils/node_map.hpp>
 #include <mockturtle/utils/stopwatch.hpp>
 #include <mockturtle/views/topo_view.hpp>
-#include <stack>
-
 #include <tweedledum/algorithms/synthesis/stg.hpp>
+#include <stack>
 
 #include <variant>
 #include <vector>
@@ -33,9 +32,6 @@ namespace mt = mockturtle;
 
 struct logic_network_synthesis_params
 {
-  /*! \brief Parameters for the mapping strategy. */
-  mapping_strategy_params mapping_ps;
-
   /*! \brief Be verbose. */
   bool verbose{false};
 };

--- a/include/caterpillar/synthesis/lhrs.hpp
+++ b/include/caterpillar/synthesis/lhrs.hpp
@@ -84,8 +84,12 @@ public:
     if ( ntk.get_node( ntk.get_constant( false ) ) != ntk.get_node( ntk.get_constant( true ) ) )
       prepare_constant( true );
 
-    MappingStrategy strategy( ntk, ps.mapping_ps );
-    const auto result = strategy.foreach_step( [&]( auto node, auto action ) {
+    MappingStrategy strategy;
+    if ( const auto result = strategy.compute_steps( ntk ); !result )
+    {
+      return false;
+    }
+    strategy.foreach_step( [&]( auto node, auto action ) {
       std::visit(
           overloaded{
               []( auto ) {},
@@ -129,7 +133,7 @@ public:
 
     prepare_outputs();
 
-    return result;
+    return true;
   }
 
 private:
@@ -354,6 +358,8 @@ private:
 
   void compute_node_as_cell( mt::node<LogicNetwork> const& node, uint32_t t, kitty::dynamic_truth_table const& func, std::vector<uint32_t> const& leave_indexes )
   {
+    (void)node;
+
     /* get control qubits */
     SetQubits controls;
     for ( auto l : leave_indexes ) {

--- a/include/caterpillar/synthesis/sat.hpp
+++ b/include/caterpillar/synthesis/sat.hpp
@@ -80,7 +80,7 @@ public:
     solver.set_nr_vars( _nr_gates + extra );
 
     /* set constraint that everything is unpebbled */
-    for ( int v = 0; v < _nr_gates; v++ )
+    for ( auto v = 0u; v < _nr_gates; v++ )
     {
       int lit = pabc::Abc_Var2Lit( v, 1 ); // zero is not negated
       solver.add_clause( &lit, &lit + 1 );
@@ -149,7 +149,7 @@ public:
             to_var_or[1] = pabc::Abc_Var2Lit( card_vars[j][k + 1], 0 );
             solver.add_clause( to_var_or, to_var_or + 2 );
           }
-          else if ( k == _pebbles - 1 )
+          else if ( k == static_cast<int>( _pebbles - 1 ) )
           {
             to_var_or[0] = pabc::Abc_Var2Lit( _nr_steps * ( _nr_gates + extra ) + j + k + 1, 1 );
             to_var_or[1] = pabc::Abc_Var2Lit( card_vars[j][k], 1 );
@@ -232,7 +232,7 @@ public:
           if ( redundant && redundant_until > 0 )
           {
             // Found redundant gate j at step i until redundant_until
-            for ( auto ii = i; ii < redundant_until; ++ii )
+            for ( int ii = i; ii < redundant_until; ++ii )
             {
               vals_step[ii][j] = 0;
             }
@@ -261,7 +261,7 @@ public:
           if ( redundant && redundant_until > 0 )
           {
             // Found redundant gate j at step i until redundant_until
-            for ( auto ii = i; ii < redundant_until; ++ii )
+            for ( int ii = i; ii < redundant_until; ++ii )
             {
               vals_step[ii][j] = 1;
             }
@@ -270,16 +270,16 @@ public:
       }
     }
 
-    for ( int s = 1; s <= _nr_steps; s++ )
+    for ( auto s = 1u; s <= _nr_steps; s++ )
     {
       auto it = steps.end();
 
-      for ( int n = 0; n < _nr_gates; n++ )
+      for ( auto n = 0u; n < _nr_gates; n++ )
       {
         if ( vals_step[s][n] != vals_step[s - 1][n] )
         {
           bool inplace = false;
-          uint32_t target;
+          uint32_t target{};
 
 #if 0
           kitty::dynamic_truth_table tt = _net.node_function( gate_to_index[n] );

--- a/include/caterpillar/synthesis/strategies/action.hpp
+++ b/include/caterpillar/synthesis/strategies/action.hpp
@@ -49,4 +49,15 @@ struct uncompute_inplace_action
 
 using mapping_strategy_action = std::variant<compute_action, uncompute_action, compute_inplace_action, uncompute_inplace_action>;
 
+namespace detail
+{
+template<class... Ts>
+struct overloaded : Ts...
+{
+  using Ts::operator()...;
+};
+template<class... Ts>
+overloaded( Ts... )->overloaded<Ts...>;
+} // namespace detail
+
 }

--- a/include/caterpillar/synthesis/strategies/bennett_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/bennett_mapping_strategy.hpp
@@ -10,9 +10,7 @@
 #include <iostream>
 #include <unordered_set>
 
-#include "action.hpp"
 #include "mapping_strategy.hpp"
-#include "../sat.hpp"
 
 #include <mockturtle/views/topo_view.hpp>
 
@@ -20,17 +18,6 @@
 
 namespace caterpillar
 {
-
-namespace detail
-{
-template<class... Ts>
-struct overloaded : Ts...
-{
-  using Ts::operator()...;
-};
-template<class... Ts>
-overloaded( Ts... )->overloaded<Ts...>;
-} // namespace detail
 
 namespace mt = mockturtle;
 
@@ -129,12 +116,12 @@ public:
           if ( ntk.is_xor( n ) )
           {
             it = this->steps().insert( it, {n, compute_inplace_action{
-                                           static_cast<uint32_t>(
-                                               target )}} );
+                                                   static_cast<uint32_t>(
+                                                       target )}} );
             ++it;
             it = this->steps().insert( it, {n, uncompute_inplace_action{
-                                           static_cast<uint32_t>(
-                                               target )}} );
+                                                   static_cast<uint32_t>(
+                                                       target )}} );
             return true;
           }
         }
@@ -143,12 +130,12 @@ public:
           if ( ntk.is_xor3( n ) )
           {
             it = this->steps().insert( it, {n, compute_inplace_action{
-                                           static_cast<uint32_t>(
-                                               target )}} );
+                                                   static_cast<uint32_t>(
+                                                       target )}} );
             ++it;
             it = this->steps().insert( it, {n, uncompute_inplace_action{
-                                           static_cast<uint32_t>(
-                                               target )}} );
+                                                   static_cast<uint32_t>(
+                                                       target )}} );
             return true;
           }
         }
@@ -167,28 +154,5 @@ public:
     return true;
   }
 };
-
-template<class MappingStrategy>
-void print_mapping_strategy( MappingStrategy const& strategy, std::ostream& os = std::cout )
-{
-  strategy.foreach_step( [&]( auto node, auto action ) {
-    std::visit(
-        detail::overloaded{
-            []( auto ) {},
-            [&]( compute_action const& ) {
-              os << fmt::format( "compute({})\n", node );
-            },
-            [&]( uncompute_action const& ) {
-              os << fmt::format( "uncompute({})\n", node );
-            },
-            [&]( compute_inplace_action const& action ) {
-              os << fmt::format( "compute_inplace({} -> {})\n", node, action.target_index );
-            },
-            [&]( uncompute_inplace_action const& action ) {
-              os << fmt::format( "uncompute_inplace({} -> {})\n", node, action.target_index );
-            }},
-        action );
-  } );
-}
 
 } // namespace caterpillar

--- a/include/caterpillar/synthesis/strategies/eager_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/eager_mapping_strategy.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <memory>
 #include <unordered_set>
 
 #include <mockturtle/traits.hpp>
@@ -19,28 +20,15 @@ namespace caterpillar
 
 namespace mt = mockturtle;
 
-/*! \brief Eager mapping strategy.
- *
- * This strategy computes each node in topological order.  At each primary
- * output, all nodes in the transitive fanin are uncomputed that are not
- * required any longer in successive steps.
- *
- * This strategy only finds compute and uncompute steps, but no inplace steps.
- */
+namespace detail
+{
+
 template<class LogicNetwork>
-class eager_mapping_strategy : public mapping_strategy<LogicNetwork>
+class eager_mapping_strategy_impl
 {
 public:
-  using base_t = mapping_strategy<LogicNetwork>;
-
-  /*! \brief Default constructor.
-   *
-   * \param ntk Logic network
-   * \param ps  Mapping strategy parameters
-   */
-  eager_mapping_strategy( LogicNetwork const& ntk, mapping_strategy_params const& ps = {} )
-      : mapping_strategy<LogicNetwork>( ntk, ps ),
-        _ref_counts( ntk, 0u )
+  eager_mapping_strategy_impl( LogicNetwork const& ntk, typename mapping_strategy<LogicNetwork>::step_vec_t& steps )
+   : _ntk( ntk ), _steps( steps ), _ref_counts( ntk, 0 )
   {
     static_assert( mt::is_network_type_v<LogicNetwork>, "LogicNetwork is not a network type" );
     static_assert( mt::has_is_constant_v<LogicNetwork>, "LogicNetwork does not implement the is_constant method" );
@@ -50,40 +38,16 @@ public:
     static_assert( mt::has_foreach_po_v<LogicNetwork>, "LogicNetwork does not implement the foreach_po method" );
     static_assert( mt::has_foreach_fanin_v<LogicNetwork>, "LogicNetwork does not implement the foreach_fanin method" );
     static_assert( mt::has_get_node_v<LogicNetwork>, "LogicNetwork does not implement the get_node method" );
-
-    init_refs();
-    run();
-  }
-
-  /*! \brief Iterate over mapping steps. */
-  virtual bool foreach_step( typename base_t::step_function_t const& fn ) const override
-  {
-    for ( auto const& [n, a] : _steps )
-    {
-      fn( n, a );
-    }
-
-    return true;
-  }
-
-private:
-  /* compute reference counters */
-  void init_refs()
-  {
-    this->_ntk.foreach_node( [&]( auto n ) {
-      _ref_counts[n] = this->_ntk.fanout_size( n );
-    } );
-    this->_ntk.foreach_po( [&]( auto f ) {
-      _pos.insert( this->_ntk.get_node( f ) );
-    } );
   }
 
   void run()
   {
-    mt::topo_view<LogicNetwork> topo{this->_ntk};
+    init_refs();
+
+    mt::topo_view<LogicNetwork> topo{_ntk};
 
     topo.foreach_node( [&]( auto n ) {
-      if ( this->_ntk.is_constant( n ) || this->_ntk.is_pi( n ) )
+      if ( _ntk.is_constant( n ) || _ntk.is_pi( n ) )
         return true;
 
       _steps.emplace_back( n, compute_action{} );
@@ -96,14 +60,26 @@ private:
     } );
   }
 
+private:
+  /* compute reference counters */
+  void init_refs()
+  {
+    _ntk.foreach_node( [&]( auto n ) {
+      _ref_counts[n] = _ntk.fanout_size( n );
+    } );
+    _ntk.foreach_po( [&]( auto f ) {
+      _pos.insert( _ntk.get_node( f ) );
+    } );
+  }
+
   void uncompute_eagerly( mt::node<LogicNetwork> n )
   {
-    if ( this->_ntk.is_constant( n ) || this->_ntk.is_pi( n ) )
+    if ( _ntk.is_constant( n ) || _ntk.is_pi( n ) )
       return;
 
-    this->_ntk.foreach_fanin( n, [&]( auto const& f ) {
-      const auto child = this->_ntk.get_node( f );
-      if ( this->_ntk.is_constant( child ) || this->_ntk.is_pi( child ) )
+    _ntk.foreach_fanin( n, [&]( auto const& f ) {
+      const auto child = _ntk.get_node( f );
+      if ( _ntk.is_constant( child ) || _ntk.is_pi( child ) )
         return;
 
       if ( --_ref_counts[f] == 0u )
@@ -115,10 +91,31 @@ private:
   }
 
 private:
+  LogicNetwork const& _ntk;
+  typename mapping_strategy<LogicNetwork>::step_vec_t& _steps;
   mt::node_map<uint32_t, LogicNetwork> _ref_counts;
   std::unordered_set<mt::node<LogicNetwork>> _pos;
+};
 
-  std::vector<std::pair<mt::node<LogicNetwork>, mapping_strategy_action>> _steps;
+}
+
+/*! \brief Eager mapping strategy.
+ *
+ * This strategy computes each node in topological order.  At each primary
+ * output, all nodes in the transitive fanin are uncomputed that are not
+ * required any longer in successive steps.
+ *
+ * This strategy only finds compute and uncompute steps, but no inplace steps.
+ */
+template<class LogicNetwork>
+class eager_mapping_strategy : public mapping_strategy<LogicNetwork>
+{
+public:
+  bool compute_steps( LogicNetwork const& ntk ) override
+  {
+    detail::eager_mapping_strategy_impl<LogicNetwork>( ntk, this->steps() ).run();
+    return true;
+  }
 };
 
 } // namespace caterpillar

--- a/include/caterpillar/synthesis/strategies/mapping_strategies.hpp
+++ b/include/caterpillar/synthesis/strategies/mapping_strategies.hpp
@@ -47,6 +47,8 @@ public:
     static_assert( mt::has_get_node_v<LogicNetwork>, "LogicNetwork does not implement the get_node method" );
   }
 
+  virtual ~bennett_mapping_strategy() = default;
+
   bool compute_steps( LogicNetwork const& ntk ) override
   {
     std::unordered_set<mt::node<LogicNetwork>> drivers;
@@ -90,6 +92,8 @@ public:
     static_assert( mt::has_fanout_size_v<LogicNetwork>, "LogicNetwork does not implement the fanout_size method" );
     static_assert( mt::has_foreach_fanin_v<LogicNetwork>, "LogicNetwork does not implement the foreach_fanin method" );
   }
+
+  virtual ~bennett_inplace_mapping_strategy() = default;
 
   bool compute_steps( LogicNetwork const& ntk ) override
   {

--- a/include/caterpillar/synthesis/strategies/mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/mapping_strategy.hpp
@@ -1,0 +1,56 @@
+/*------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+| Author(s): Mathias Soeken and Giulia Meuli
+*-----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include <mockturtle/traits.hpp>
+
+#include "action.hpp"
+
+namespace caterpillar
+{
+
+struct mapping_strategy_params
+{
+  /*! \brief Show progress bar. */
+  bool progress{false};
+
+  /*! \brief Maximum number of pebbles to use, if supported by mapping strategy (0 means no limit). */
+  uint32_t pebble_limit{0u};
+
+  /*! \brief Conflict limit for the SAT solver (0 means no limit). */
+  uint32_t conflict_limit{0u};
+
+  /*! \brief Increment pebble numbers, if timeout. */
+  bool increment_on_timeout{false};
+
+  /*! \brief Decrement pebble numbers, if satisfiable. */
+  bool decrement_on_success{false};
+};
+
+template<class LogicNetwork>
+class mapping_strategy
+{
+public:
+  using step_function_t = std::function<void(mockturtle::node<LogicNetwork> const&, mapping_strategy_action const&)>;
+
+  mapping_strategy( LogicNetwork const& ntk, mapping_strategy_params const& ps = {} )
+      : _ntk( ntk ),
+        _ps( ps )
+  {
+  }
+
+  virtual bool foreach_step( step_function_t const& fn ) const = 0;
+
+protected:
+  LogicNetwork const& _ntk;
+  mapping_strategy_params _ps;
+};
+
+} // namespace caterpillar

--- a/include/caterpillar/synthesis/strategies/mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/mapping_strategy.hpp
@@ -39,18 +39,26 @@ class mapping_strategy
 {
 public:
   using step_function_t = std::function<void(mockturtle::node<LogicNetwork> const&, mapping_strategy_action const&)>;
+  using step_vec_t = std::vector<std::pair<mockturtle::node<LogicNetwork>, mapping_strategy_action>>;
 
-  mapping_strategy( LogicNetwork const& ntk, mapping_strategy_params const& ps = {} )
-      : _ntk( ntk ),
-        _ps( ps )
+  virtual bool compute_steps( LogicNetwork const& ntk ) = 0;
+
+  void foreach_step( step_function_t const& fn ) const
   {
+    for ( auto const& [n, a] : _steps )
+    {
+      fn( n, a );
+    }
   }
 
-  virtual bool foreach_step( step_function_t const& fn ) const = 0;
-
 protected:
-  LogicNetwork const& _ntk;
-  mapping_strategy_params _ps;
+  step_vec_t& steps()
+  {
+    return _steps;
+  }
+
+private:
+  step_vec_t _steps;
 };
 
 } // namespace caterpillar

--- a/include/caterpillar/synthesis/strategies/pebbling_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/pebbling_mapping_strategy.hpp
@@ -1,0 +1,92 @@
+/*------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+| Author(s): Giulia Meuli
+*-----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "mapping_strategy.hpp"
+#include "../sat.hpp"
+
+#include <mockturtle/utils/progress_bar.hpp>
+
+namespace caterpillar
+{
+
+namespace mt = mockturtle;
+
+template<class LogicNetwork>
+class pebbling_mapping_strategy : public mapping_strategy<LogicNetwork>
+{
+public:
+  static_assert( mt::is_network_type_v<LogicNetwork>, "LogicNetwork is not a network type" );
+  static_assert( mt::has_is_pi_v<LogicNetwork>, "LogicNetwork does not implement the is_pi method" );
+  static_assert( mt::has_foreach_fanin_v<LogicNetwork>, "LogicNetwork does not implement the foreach_fanin method" );
+  static_assert( mt::has_foreach_gate_v<LogicNetwork>, "LogicNetwork does not implement the foreach_gate method" );
+  static_assert( mt::has_num_gates_v<LogicNetwork>, "LogicNetwork does not implement the num_gates method" );
+  static_assert( mt::has_foreach_po_v<LogicNetwork>, "LogicNetwork does not implement the foreach_po method" );
+  static_assert( mt::has_index_to_node_v<LogicNetwork>, "LogicNetwork does not implement the index_to_node method" );
+
+  bool compute_steps( LogicNetwork const& ntk ) override
+  {
+    mapping_strategy_params ps;
+
+    assert( !ps.decrement_on_success || !ps.increment_on_timeout );
+    std::vector<std::pair<mockturtle::node<LogicNetwork>, mapping_strategy_action>> store_steps;
+    auto limit = ps.pebble_limit;
+    unsigned max_steps = 100;
+    while ( true )
+    {
+      pebble_solver<LogicNetwork> solver( ntk, limit );
+      solver.initialize();
+
+      mockturtle::progress_bar bar( 100, "|{0}| current step = {1}", ps.progress );
+      percy::synth_result result;
+
+      do
+      {
+        if ( solver.current_step() >= max_steps )
+        {
+          result = percy::timeout;
+          break;
+        }
+
+        bar( std::min<uint32_t>( solver.current_step(), 100 ), solver.current_step() );
+        solver.add_step();
+        result = solver.solve( ps.conflict_limit );
+      } while ( result == percy::failure );
+
+      if ( result == percy::timeout )
+      {
+        if ( ps.increment_on_timeout )
+        {
+          limit++;
+          continue;
+        }
+        else if ( !ps.decrement_on_success )
+          return false;
+      }
+      else if ( result == percy::success )
+      {
+        this->steps() = solver.extract_result();
+        if ( ps.decrement_on_success )
+        {
+          limit--;
+          continue;
+        }
+      }
+
+      if ( this->steps().empty() )
+        return false;
+
+      return true;
+    }
+  }
+};
+
+}

--- a/include/caterpillar/synthesis/strategies/pebbling_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/pebbling_mapping_strategy.hpp
@@ -20,11 +20,29 @@ namespace caterpillar
 
 namespace mt = mockturtle;
 
+struct pebbling_mapping_strategy_params
+{
+  /*! \brief Show progress bar. */
+  bool progress{false};
+
+  /*! \brief Maximum number of pebbles to use, if supported by mapping strategy (0 means no limit). */
+  uint32_t pebble_limit{0u};
+
+  /*! \brief Conflict limit for the SAT solver (0 means no limit). */
+  uint32_t conflict_limit{0u};
+
+  /*! \brief Increment pebble numbers, if timeout. */
+  bool increment_on_timeout{false};
+
+  /*! \brief Decrement pebble numbers, if satisfiable. */
+  bool decrement_on_success{false};
+};
+
 template<class LogicNetwork>
 class pebbling_mapping_strategy : public mapping_strategy<LogicNetwork>
 {
 public:
-  pebbling_mapping_strategy( mapping_strategy_params const& ps = {} )
+  pebbling_mapping_strategy( pebbling_mapping_strategy_params const& ps = {} )
     : ps( ps )
   {
     static_assert( mt::is_network_type_v<LogicNetwork>, "LogicNetwork is not a network type" );
@@ -91,7 +109,7 @@ public:
   }
 
 private:
-  mapping_strategy_params ps;
+  pebbling_mapping_strategy_params ps;
 };
 
 }

--- a/include/caterpillar/synthesis/strategies/pebbling_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/pebbling_mapping_strategy.hpp
@@ -24,18 +24,20 @@ template<class LogicNetwork>
 class pebbling_mapping_strategy : public mapping_strategy<LogicNetwork>
 {
 public:
-  static_assert( mt::is_network_type_v<LogicNetwork>, "LogicNetwork is not a network type" );
-  static_assert( mt::has_is_pi_v<LogicNetwork>, "LogicNetwork does not implement the is_pi method" );
-  static_assert( mt::has_foreach_fanin_v<LogicNetwork>, "LogicNetwork does not implement the foreach_fanin method" );
-  static_assert( mt::has_foreach_gate_v<LogicNetwork>, "LogicNetwork does not implement the foreach_gate method" );
-  static_assert( mt::has_num_gates_v<LogicNetwork>, "LogicNetwork does not implement the num_gates method" );
-  static_assert( mt::has_foreach_po_v<LogicNetwork>, "LogicNetwork does not implement the foreach_po method" );
-  static_assert( mt::has_index_to_node_v<LogicNetwork>, "LogicNetwork does not implement the index_to_node method" );
+  pebbling_mapping_strategy( mapping_strategy_params const& ps = {} )
+    : ps( ps )
+  {
+    static_assert( mt::is_network_type_v<LogicNetwork>, "LogicNetwork is not a network type" );
+    static_assert( mt::has_is_pi_v<LogicNetwork>, "LogicNetwork does not implement the is_pi method" );
+    static_assert( mt::has_foreach_fanin_v<LogicNetwork>, "LogicNetwork does not implement the foreach_fanin method" );
+    static_assert( mt::has_foreach_gate_v<LogicNetwork>, "LogicNetwork does not implement the foreach_gate method" );
+    static_assert( mt::has_num_gates_v<LogicNetwork>, "LogicNetwork does not implement the num_gates method" );
+    static_assert( mt::has_foreach_po_v<LogicNetwork>, "LogicNetwork does not implement the foreach_po method" );
+    static_assert( mt::has_index_to_node_v<LogicNetwork>, "LogicNetwork does not implement the index_to_node method" );
+  }
 
   bool compute_steps( LogicNetwork const& ntk ) override
   {
-    mapping_strategy_params ps;
-
     assert( !ps.decrement_on_success || !ps.increment_on_timeout );
     std::vector<std::pair<mockturtle::node<LogicNetwork>, mapping_strategy_action>> store_steps;
     auto limit = ps.pebble_limit;
@@ -87,6 +89,9 @@ public:
       return true;
     }
   }
+
+private:
+  mapping_strategy_params ps;
 };
 
 }

--- a/include/caterpillar/synthesis/strategies/xag_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/xag_mapping_strategy.hpp
@@ -3,7 +3,9 @@
 | See accompanying file /LICENSE for details.
 | Author(s): Giulia Meuli
 *------------------------------------------------------------------------------------------------*/
-#include "../sat.hpp"
+
+#pragma once
+
 #include "mapping_strategy.hpp"
 #include <caterpillar/stg_gate.hpp>
 #include <mockturtle/networks/xag.hpp>

--- a/include/caterpillar/synthesis/strategies/xag_mapping_strategy.hpp
+++ b/include/caterpillar/synthesis/strategies/xag_mapping_strategy.hpp
@@ -3,13 +3,12 @@
 | See accompanying file /LICENSE for details.
 | Author(s): Giulia Meuli
 *------------------------------------------------------------------------------------------------*/
-#include <mockturtle/networks/xag.hpp>
-#include <mockturtle/networks/xag.hpp>
-#include <tweedledum/networks/netlist.hpp>
-#include <caterpillar/stg_gate.hpp>
-#include <mockturtle/views/topo_view.hpp>
-#include "mapping_strategies.hpp"
 #include "../sat.hpp"
+#include "mapping_strategy.hpp"
+#include <caterpillar/stg_gate.hpp>
+#include <mockturtle/networks/xag.hpp>
+#include <mockturtle/views/topo_view.hpp>
+#include <tweedledum/networks/netlist.hpp>
 
 namespace caterpillar
 {
@@ -21,186 +20,158 @@ struct SignalCone
   std::vector<uint32_t> cone_nodes;
 };
 
-class xag_mapping_strategy
+class xag_mapping_strategy : public mapping_strategy<mockturtle::xag_network>
 {
 
+  void accumulate_leaves( mockturtle::topo_view<mockturtle::xag_network> const& xag, SignalCone& cone, mockturtle::signal<mockturtle::xag_network> s )
+  {
+    auto n = xag.get_node( s );
 
-	void accumulate_leaves(SignalCone& cone, mockturtle::signal<mockturtle::xag_network> s)
-	{
-    auto n = xag.get_node(s);
-
-    if(xag.is_xor(n)) 
+    if ( xag.is_xor( n ) )
     {
-      cone.cone_nodes.push_back(n);
+      cone.cone_nodes.push_back( n );
 
       xag.foreach_fanin( n, [&]( auto si ) {
-        accumulate_leaves( cone, si);
-      });
+        accumulate_leaves( xag, cone, si );
+      } );
     }
     else
-      cone.leaves.push_back(n);
-	}
+      cone.leaves.push_back( n );
+  }
 
-  std::vector<SignalCone> get_cones ( mockturtle::node<mockturtle::xag_network> node)
+  std::vector<SignalCone> get_cones( mockturtle::topo_view<mockturtle::xag_network> const& xag, mockturtle::node<mockturtle::xag_network> node )
   {
     std::vector<SignalCone> cones;
-        
+
     xag.foreach_fanin( node, [&]( auto s ) {
       SignalCone cone;
       cone.node = node;
 
-      accumulate_leaves(cone, s);
+      accumulate_leaves( xag, cone, s );
 
-      std::sort(cone.cone_nodes.begin(), cone.cone_nodes.end());
+      std::sort( cone.cone_nodes.begin(), cone.cone_nodes.end() );
       cones.push_back( cone );
     } );
 
     return cones;
   }
 
-  void order_sets(std::vector<SignalCone>& cones)
+  void order_sets( std::vector<SignalCone>& cones )
   {
     auto leav_1 = cones[0].leaves;
     auto leav_2 = cones[1].leaves;
 
-    std::sort(leav_1.begin(), leav_1.end());
-    std::sort(leav_2.begin(), leav_2.end());
+    std::sort( leav_1.begin(), leav_1.end() );
+    std::sort( leav_2.begin(), leav_2.end() );
 
-    leav_1.erase(std::unique(leav_1.begin(), leav_1.end()), leav_1.end());
-    leav_2.erase(std::unique(leav_2.begin(), leav_2.end()), leav_2.end());
+    leav_1.erase( std::unique( leav_1.begin(), leav_1.end() ), leav_1.end() );
+    leav_2.erase( std::unique( leav_2.begin(), leav_2.end() ), leav_2.end() );
 
     std::vector<uint32_t> diff_0, diff_1;
     std::set_difference( leav_1.begin(), leav_1.end(), leav_1.begin(), leav_1.end(), std::back_inserter( diff_0 ) );
     std::set_difference( leav_1.begin(), leav_1.end(), leav_1.begin(), leav_1.end(), std::back_inserter( diff_1 ) );
 
-    for(auto elem : leav_1)
+    for ( auto elem : leav_1 )
     {
-      if (std::find(diff_0.begin(), diff_0.end(), elem) != diff_0.end())
+      if ( std::find( diff_0.begin(), diff_0.end(), elem ) != diff_0.end() )
       {
         auto it_move = std::find( leav_1.begin(), leav_1.end(), elem );
         std::move( it_move, it_move + 1, leav_1.begin() );
         break;
       }
     }
-    for(auto elem : leav_1)
+    for ( auto elem : leav_1 )
     {
-      if (std::find(diff_1.begin(), diff_1.end(), elem) != diff_1.end())
+      if ( std::find( diff_1.begin(), diff_1.end(), elem ) != diff_1.end() )
       {
         auto it_move = std::find( leav_1.begin(), leav_1.end(), elem );
         std::move( it_move, it_move + 1, leav_1.begin() );
         break;
       }
     }
-
   }
 
-  std::vector<std::pair<mockturtle::node<mockturtle::xag_network>, mapping_strategy_action>> compute_cones(std::vector<SignalCone> const& cones, bool uncompute_and)
+  std::vector<std::pair<mockturtle::node<mockturtle::xag_network>, mapping_strategy_action>> compute_cones( mockturtle::topo_view<mockturtle::xag_network> const& xag, std::vector<SignalCone> const& cones, bool uncompute_and )
   {
     std::vector<std::pair<mockturtle::node<mockturtle::xag_network>, mapping_strategy_action>> comp_steps;
 
-    for(auto cone : cones)
+    for ( auto cone : cones )
     {
-      auto target = xag.node_to_index(cone.leaves[0]);
-      for( auto node : cone.cone_nodes)
+      auto target = xag.node_to_index( cone.leaves[0] );
+      for ( auto node : cone.cone_nodes )
       {
-        comp_steps.push_back( {node, compute_inplace_action{ static_cast<uint32_t>(target )}} );
+        comp_steps.push_back( {node, compute_inplace_action{static_cast<uint32_t>( target )}} );
       }
     }
-     
-    if(uncompute_and)
+
+    if ( uncompute_and )
       comp_steps.push_back( {cones[0].node, uncompute_action{}} );
-    else 
+    else
       comp_steps.push_back( {cones[0].node, compute_action{}} );
 
-
-    for(auto cone : cones)
+    for ( auto cone : cones )
     {
-      auto target = xag.node_to_index(cone.leaves[0]);
-      for( auto node : cone.cone_nodes)
+      auto target = xag.node_to_index( cone.leaves[0] );
+      for ( auto node : cone.cone_nodes )
       {
 
-        comp_steps.push_back( {node, uncompute_inplace_action{ static_cast<uint32_t>(target )}} );
+        comp_steps.push_back( {node, uncompute_inplace_action{static_cast<uint32_t>( target )}} );
       }
     }
     return comp_steps;
-
   }
 
-  std::vector<std::pair<mockturtle::node<mockturtle::xag_network>, mapping_strategy_action>> compute_xor(std::vector<SignalCone> const& cones)
+  std::vector<std::pair<mockturtle::node<mockturtle::xag_network>, mapping_strategy_action>> compute_xor( std::vector<SignalCone> const& cones )
   {
     std::vector<std::pair<mockturtle::node<mockturtle::xag_network>, mapping_strategy_action>> comp_steps;
     comp_steps.push_back( {cones[0].node, compute_action{}} );
-    for(auto cone : cones)
+    for ( auto cone : cones )
     {
-      for( auto node : cone.cone_nodes)
+      for ( auto node : cone.cone_nodes )
       {
         comp_steps.push_back( {node, compute_action{}} );
       }
     }
     return comp_steps;
-    
   }
 
-
 public:
-  xag_mapping_strategy( mockturtle::xag_network const& xag, mapping_strategy_params const& ps = {} )
-  : xag(mockturtle::topo_view( xag ))
+  bool compute_steps( mockturtle::xag_network const& ntk ) override
   {
-    
-    (void)ps;
-
+    mockturtle::topo_view xag{ntk};
     std::vector<mockturtle::node<mockturtle::xag_network>> drivers;
     xag.foreach_po( [&]( auto const& f ) { drivers.push_back( xag.get_node( f ) ); } );
 
-    auto it = steps.begin();
+    auto it = steps().begin();
     xag.foreach_node( [&]( auto node ) {
-      
-      if (xag.is_and(node))
+      if ( xag.is_and( node ) )
       {
-        auto cones  = get_cones (node);
+        auto cones = get_cones( xag, node );
 
-        order_sets(cones);
+        order_sets( cones );
 
         /* compute step */
-        auto cc = compute_cones(cones, false);
-        it = steps.insert( it, cc.begin(), cc.end() );
+        auto cc = compute_cones( xag, cones, false );
+        it = steps().insert( it, cc.begin(), cc.end() );
         it = it + cc.size();
 
-        if ( std::find(drivers.begin(), drivers.end(), node) == drivers.end() )
+        if ( std::find( drivers.begin(), drivers.end(), node ) == drivers.end() )
         {
-          auto uc = compute_cones(cones, true);
-          it = steps.insert( it, uc.begin(), uc.end());
+          auto uc = compute_cones( xag, cones, true );
+          it = steps().insert( it, uc.begin(), uc.end() );
         }
-          
-
       }
-      else if( std::find(drivers.begin(), drivers.end(), node) != drivers.end())
+      else if ( std::find( drivers.begin(), drivers.end(), node ) != drivers.end() )
       {
-        auto cones  = get_cones (node);
+        auto cones = get_cones( xag, node );
 
-        auto xc = compute_xor(cones);
-        it = steps.insert( it, xc.begin(), xc.end() );
-
+        auto xc = compute_xor( cones );
+        it = steps().insert( it, xc.begin(), xc.end() );
       }
     } );
 
-    
-  }
-
-  template<class Fn>
-  inline bool foreach_step( Fn&& fn ) const
-  {
-    for ( auto const& [n, a] : steps )
-    {
-      fn( n, a );
-    }
-
     return true;
   }
-
-private:
-  std::vector<std::pair<mockturtle::node<mockturtle::xag_network>, mapping_strategy_action>> steps;
-  mockturtle::topo_view<mockturtle::xag_network> xag;
 };
 
-}
+} // namespace caterpillar

--- a/lib/easy/easy/sat/sat_solver.hpp
+++ b/lib/easy/easy/sat/sat_solver.hpp
@@ -41,21 +41,21 @@ struct sat_solver
 
   struct result
   {
-    result( state_t state = l_Undef )
+    result( state_t state = Glucose::l_Undef )
         : state( state )
     {
     }
 
     result( const model_t& m )
-        : state( l_True ), model( m )
+        : state( Glucose::l_True ), model( m )
     {
     }
 
-    inline operator bool() const { return ( state == l_True ); }
+    inline operator bool() const { return ( state == Glucose::l_True ); }
 
-    inline bool is_sat() const { return ( state == l_True ); }
-    inline bool is_unsat() const { return ( state == l_False ); }
-    inline bool is_undef() const { return ( state == l_Undef ); }
+    inline bool is_sat() const { return ( state == Glucose::l_True ); }
+    inline bool is_unsat() const { return ( state == Glucose::l_False ); }
+    inline bool is_undef() const { return ( state == Glucose::l_Undef ); }
 
     state_t state;
     model_t model;
@@ -145,14 +145,14 @@ inline sat_solver::result sat_solver::solve( constraints& constraints, const ass
   else
   {
     const auto solver_result = _solver->solveLimited( assume );
-    if ( solver_result == l_Undef || int32_t(_solver->conflicts) >= _conflict_limit )
+    if ( solver_result == Glucose::l_Undef || int32_t(_solver->conflicts) >= _conflict_limit )
     {
-      return result( l_Undef );
+      return result( Glucose::l_Undef );
     }
     else
     {
-      assert( solver_result == l_True || solver_result == l_False );
-      sat = solver_result == l_True;
+      assert( solver_result == Glucose::l_True || solver_result == Glucose::l_False );
+      sat = solver_result == Glucose::l_True;
     }
   }
 
@@ -167,7 +167,7 @@ inline sat_solver::result sat_solver::solve( constraints& constraints, const ass
   }
   else
   {
-    return result( sat ? l_True : l_False );
+    return result( sat ? Glucose::l_True : Glucose::l_False );
   }
 }
 

--- a/lib/easy/easy/sat2/sat_solver.hpp
+++ b/lib/easy/easy/sat2/sat_solver.hpp
@@ -347,17 +347,17 @@ public:
     }
 
     auto const result = _glucose->solveLimited( ass );
-    if ( result == l_Undef || int32_t(_glucose->conflicts) >= _ps.budget )
+    if ( result == Glucose::l_Undef || int32_t(_glucose->conflicts) >= _ps.budget )
     {
       return ( _state = state::dirty );
     }
-    else if ( result == l_True )
+    else if ( result == Glucose::l_True )
     {
       return ( _state = state::sat );
     }
     else
     {
-      assert( result == l_False );
+      assert( result == Glucose::l_False );
       return ( _state = state::unsat );
     }
   }
@@ -391,7 +391,7 @@ public:
     utils::dynamic_bitset<> m;
     for ( auto i = 0u; i < size; ++i )
     {
-      m.push_back( _glucose->model[i] == l_True );
+      m.push_back( _glucose->model[i] == Glucose::l_True );
     }
     return model( m );
   }

--- a/lib/glucose/include/glucose/glucose.hpp
+++ b/lib/glucose/include/glucose/glucose.hpp
@@ -1945,10 +1945,6 @@ const Lit lit_Error = { -1 };  // }
 //       does enough constant propagation to produce sensible code, and this appears to be somewhat
 //       fragile unfortunately.
 
-#define l_True  (Glucose::lbool((uint8_t)0)) // gcc does not do constant propagation if these are real constants.
-#define l_False (Glucose::lbool((uint8_t)1))
-#define l_Undef (Glucose::lbool((uint8_t)2))
-
 class lbool {
     uint8_t value;
 
@@ -1977,6 +1973,10 @@ public:
 };
 inline int   toInt  (lbool l) { return l.value; }
 inline lbool toLbool(int   v) { return lbool((uint8_t)v);  }
+
+static const Glucose::lbool l_True = (Glucose::lbool((uint8_t)0)); // gcc does not do constant propagation if these are real constants.
+static const Glucose::lbool l_False = (Glucose::lbool((uint8_t)1));
+static const Glucose::lbool l_Undef = (Glucose::lbool((uint8_t)2));
 
 //=================================================================================================
 // Clause -- a simple class for representing a clause:

--- a/test/best_fit_mapping_strategy.cpp
+++ b/test/best_fit_mapping_strategy.cpp
@@ -35,8 +35,8 @@ TEST_CASE( "Best-fit mapping strategy for 3-bit sorting network", "[best_fit_map
   sorter.create_po( w5 );
   sorter.create_po( w6 );
 
-  best_fit_mapping_strategy strategy( sorter );
-  uint32_t compute{0u}, uncompute{0u};
+  best_fit_mapping_strategy<aig_network> strategy;
+  CHECK( strategy.compute_steps( sorter ) );
 
   netlist<stg_gate> circ;
   logic_network_synthesis_stats st;

--- a/test/best_fit_mapping_strategy.cpp
+++ b/test/best_fit_mapping_strategy.cpp
@@ -35,12 +35,10 @@ TEST_CASE( "Best-fit mapping strategy for 3-bit sorting network", "[best_fit_map
   sorter.create_po( w5 );
   sorter.create_po( w6 );
 
-  best_fit_mapping_strategy<aig_network> strategy;
-  CHECK( strategy.compute_steps( sorter ) );
-
   netlist<stg_gate> circ;
   logic_network_synthesis_stats st;
-  logic_network_synthesis<netlist<stg_gate>, aig_network, best_fit_mapping_strategy<aig_network>>(circ, sorter, {}, {}, &st);
+  best_fit_mapping_strategy<aig_network> strategy;
+  logic_network_synthesis(circ, sorter, strategy, {}, {}, &st);
 
   const auto sorter2 = circuit_to_logic_network<aig_network>(circ, st.i_indexes, st.o_indexes);
   CHECK( sorter2 );

--- a/test/eager_mapping_strategy.cpp
+++ b/test/eager_mapping_strategy.cpp
@@ -35,7 +35,8 @@ TEST_CASE( "Eager mapping strategy for 3-bit sorting network", "[eager_mapping_s
   sorter.create_po( w5 );
   sorter.create_po( w6 );
 
-  eager_mapping_strategy strategy( sorter );
+  eager_mapping_strategy<aig_network> strategy;
+  CHECK( strategy.compute_steps( sorter ) );
   uint32_t compute{0u}, uncompute{0u};
 
   strategy.foreach_step( [&]( auto, auto a ) {

--- a/test/eager_mapping_strategy.cpp
+++ b/test/eager_mapping_strategy.cpp
@@ -62,8 +62,9 @@ TEST_CASE( "Eager mapping strategy for 3-bit sorting network", "[eager_mapping_s
   CHECK( uncompute == 3u );
 
   netlist<stg_gate> circ;
+  eager_mapping_strategy<aig_network> strategy2;
   logic_network_synthesis_stats st;
-  logic_network_synthesis<netlist<stg_gate>, aig_network, eager_mapping_strategy<aig_network>>(circ, sorter, {}, {}, &st);
+  logic_network_synthesis(circ, sorter, strategy2, {}, {}, &st);
 
   const auto sorter2 = circuit_to_logic_network<aig_network>(circ, st.i_indexes, st.o_indexes);
   CHECK( sorter2 );

--- a/test/lhrs.cpp
+++ b/test/lhrs.cpp
@@ -29,8 +29,9 @@ TEST_CASE( "synthesize AND", "[lhrs AND test]" )
   /*auto o = */aig.create_po( c );
 
   netlist<stg_gate> revnet;
+  bennett_inplace_mapping_strategy<aig_network> strategy;
   logic_network_synthesis_stats st;
-  logic_network_synthesis( revnet, aig, stg_from_pprm(), {}, &st );
+  logic_network_synthesis( revnet, aig, strategy, stg_from_pprm(), {}, &st );
 
   CHECK( revnet.num_gates() == 1 );
   CHECK( revnet.num_qubits() == 3 );
@@ -68,8 +69,9 @@ TEST_CASE( "synthesize OR", "[lhrs OR test]" )
   /*auto o = */aig.create_po( c );
 
   netlist<stg_gate> revnet;
+  bennett_inplace_mapping_strategy<aig_network> strategy;
   logic_network_synthesis_stats st;
-  logic_network_synthesis( revnet, aig, stg_from_pprm(), {}, &st);
+  logic_network_synthesis( revnet, aig, strategy, stg_from_pprm(), {}, &st);
 
   CHECK( revnet.num_gates() == 2 );
   CHECK( revnet.num_qubits() == 3 );
@@ -118,7 +120,8 @@ TEST_CASE( "synthesize multioutput maj3", "[multiout MAJ]" )
   netlist<stg_gate> t_net;
 
   logic_network_synthesis_stats st;
-  logic_network_synthesis( t_net, mig, stg_from_pprm(), {}, &st );
+  bennett_inplace_mapping_strategy<mig_network> strategy;
+  logic_network_synthesis( t_net, mig, strategy, stg_from_pprm(), {}, &st );
 
   const auto ntk = circuit_to_logic_network<xag_network>( t_net, st.i_indexes, st.o_indexes );
 

--- a/test/lhrs.cpp
+++ b/test/lhrs.cpp
@@ -7,6 +7,7 @@
 
 
 #include <caterpillar/synthesis/lhrs.hpp>
+#include <caterpillar/synthesis/strategies/bennett_mapping_strategy.hpp>
 #include <caterpillar/stg_gate.hpp>
 #include <caterpillar/verification/circuit_to_logic_network.hpp>
 

--- a/test/pebbling_mapping_strategy.cpp
+++ b/test/pebbling_mapping_strategy.cpp
@@ -35,12 +35,10 @@ TEST_CASE( "Pebble mapping strategy for 3-bit sorting network", "[pebbling_mappi
   sorter.create_po( w5 );
   sorter.create_po( w6 );
 
-  pebbling_mapping_strategy<aig_network> strategy;
-  CHECK( strategy.compute_steps( sorter ) );
-
   netlist<stg_gate> circ;
+  pebbling_mapping_strategy<aig_network> strategy;
   logic_network_synthesis_stats st;
-  logic_network_synthesis<netlist<stg_gate>, aig_network, pebbling_mapping_strategy<aig_network>>(circ, sorter, {}, {}, &st);
+  logic_network_synthesis(circ, sorter, strategy, {}, {}, &st);
 
   const auto sorter2 = circuit_to_logic_network<aig_network>(circ, st.i_indexes, st.o_indexes);
   CHECK( sorter2 );

--- a/test/pebbling_mapping_strategy.cpp
+++ b/test/pebbling_mapping_strategy.cpp
@@ -1,0 +1,48 @@
+#include <catch.hpp>
+
+#include <cstdint>
+
+#include <caterpillar/stg_gate.hpp>
+#include <caterpillar/synthesis/lhrs.hpp>
+#include <caterpillar/synthesis/strategies/pebbling_mapping_strategy.hpp>
+#include <caterpillar/verification/circuit_to_logic_network.hpp>
+#include <kitty/static_truth_table.hpp>
+#include <mockturtle/algorithms/simulation.hpp>
+#include <mockturtle/networks/aig.hpp>
+#include <tweedledum/io/write_unicode.hpp>
+#include <tweedledum/networks/netlist.hpp>
+
+TEST_CASE( "Pebble mapping strategy for 3-bit sorting network", "[pebbling_mapping_strategy]" )
+{
+  using namespace caterpillar;
+  using namespace caterpillar::detail;
+  using namespace mockturtle;
+  using namespace tweedledum;
+
+  aig_network sorter;
+  const auto a = sorter.create_pi();
+  const auto b = sorter.create_pi();
+  const auto c = sorter.create_pi();
+
+  const auto w1 = sorter.create_and( a, b );
+  const auto w2 = sorter.create_and( c, w1 );
+  const auto w3 = sorter.create_and( !a, !b );
+  const auto w4 = sorter.create_and( !c, !w1 );
+  const auto w5 = sorter.create_and( !w3, !w4 );
+  const auto w6 = sorter.create_or( c, !w3 );
+
+  sorter.create_po( w2 );
+  sorter.create_po( w5 );
+  sorter.create_po( w6 );
+
+  pebbling_mapping_strategy<aig_network> strategy;
+  CHECK( strategy.compute_steps( sorter ) );
+
+  netlist<stg_gate> circ;
+  logic_network_synthesis_stats st;
+  logic_network_synthesis<netlist<stg_gate>, aig_network, pebbling_mapping_strategy<aig_network>>(circ, sorter, {}, {}, &st);
+
+  const auto sorter2 = circuit_to_logic_network<aig_network>(circ, st.i_indexes, st.o_indexes);
+  CHECK( sorter2 );
+  CHECK( simulate<kitty::static_truth_table<3>>( sorter ) == simulate<kitty::static_truth_table<3>>( *sorter2 ) );
+}

--- a/test/xag_synthesis.cpp
+++ b/test/xag_synthesis.cpp
@@ -32,7 +32,8 @@ TEST_CASE("synthesize simple xag", "[XAG synthesis]")
   logic_network_synthesis_params ps;
   //ps.verbose = true;
 
-  logic_network_synthesis<netlist<stg_gate>, xag_network, xag_mapping_strategy>( qnet, xag, {}, ps );
+  xag_mapping_strategy strategy;
+  logic_network_synthesis( qnet, xag, strategy, {}, ps );
 
   std::vector<stg_gate> gates;
   qnet.foreach_cgate([&gates] (auto g){ gates.push_back(g.gate); });
@@ -71,7 +72,8 @@ TEST_CASE("synthesize simple xag 2", "[XAG synthesis-2]")
   logic_network_synthesis_stats st;
   //ps.verbose = true;
 
-  logic_network_synthesis<netlist<stg_gate>, xag_network, xag_mapping_strategy>( qnet, xag, {}, ps, &st );
+  xag_mapping_strategy strategy;
+  logic_network_synthesis( qnet, xag, strategy, {}, ps, &st );
 
   auto tt_xag = simulate<kitty::static_truth_table<4>>( xag )[0];
   const auto ntk = circuit_to_logic_network<xag_network, netlist<stg_gate>>( qnet, st.i_indexes, st.o_indexes );


### PR DESCRIPTION
This PR changes the interface for mapping strategies. Each of them have a common base class `mapping_strategy<LogicNetwork>` and they are passed as a parameter to `logic_network_synthesis`. Like that, each of the strategies can be configured with individual parameters, e.g., number of pebbles in pebbling strategies, or cut sizes in best fit strategies.
